### PR TITLE
Fix network default script

### DIFF
--- a/package/base-files/files/etc/board.d/99-default_network
+++ b/package/base-files/files/etc/board.d/99-default_network
@@ -8,7 +8,7 @@ board_config_update
 
 json_is_a network object && exit 0
 
-ucidef_set_interface_lan 'eth0'
+ucidef_set_interface_lan 'eth2'
 [ -d /sys/class/net/eth1 ] && ucidef_set_interface_wan 'eth1'
 
 board_config_flush


### PR DESCRIPTION

Fix network default script package/base-files/files/etc/board.d/99-default_network to use eth2 as a lan